### PR TITLE
Add interoperability with email account validity

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ across a closed federation. When users update their global `im.vector.hide_profi
 account data with `{"hide_profile": True}`, they are removed from this discovery room,
 and added to a local database table to filter them out from local results.
 
+This module can also interact with the [synapse-email-account-validity](https://github.com/matrix-org/synapse-email-account-validity)
+module. If this compatibility feature is enabled, the module will automatically scan for
+expired and renewed users every hour. It will then add expired users to the red list and
+remove renewed users from it (without updating the users' account data).
+
 ## Installation
 
 From the virtual environment that you use for Synapse, install this module with:
@@ -24,6 +29,9 @@ modules:
       # ID of the room used for user discovery.
       # Optional, defaults to no room.
       discovery_room: "!someroom:example.com"
+      # Whether to enable compatibility with the synapse-email-account-validity module.
+      # Optional, defaults to false.
+      use_email_account_validity: false
 ```
 
 

--- a/tchap_red_list/__init__.py
+++ b/tchap_red_list/__init__.py
@@ -90,13 +90,6 @@ class RedListManager:
         desired_status = bool(content.get("hide_profile"))
         current_status, because_expired = await self._get_user_status(user_id)
 
-        # If the user's desired status is the same as their current one, don't do
-        # anything, except if because_expired is True (because in this case it can be a
-        # user that was added to the red list after expiring, haven't been removed yet,
-        # and manually re-added themselves).
-        if current_status == desired_status and because_expired is False:
-            return
-
         if current_status == desired_status:
             if because_expired is True:
                 # There can be a delay between the user renewing their account (from an

--- a/tests/test_account_validity.py
+++ b/tests/test_account_validity.py
@@ -1,4 +1,4 @@
-# Copyright 2022 The Matrix.org Foundation C.I.C.
+# Copyright 2022 New Vector Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_account_validity.py
+++ b/tests/test_account_validity.py
@@ -1,0 +1,171 @@
+# Copyright 2022 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import time
+
+import aiounittest
+
+from tchap_red_list import ACCOUNT_DATA_TYPE
+from tests import SQLiteStore, create_module
+
+
+class AccountValidityRedListTestCase(aiounittest.AsyncTestCase):
+    expired_user = "@expired:example.com"
+    valid_user = "@valid:example.com"
+
+    def _setup_account_validity(self, store: SQLiteStore) -> None:
+        """Create a table mocking the one created by synapse-email-account-validity,
+        except only with the columns used by the red list module, and populate it.
+
+        Args:
+            store: the store to use to create and populate the table.
+        """
+        txn = store.conn.cursor()
+
+        txn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS email_account_validity(
+                user_id TEXT PRIMARY KEY,
+                expiration_ts_ms BIGINT NOT NULL
+            )
+            """,
+            (),
+        )
+
+        now_ms = int(time.time() * 1000)
+
+        txn.execute(
+            "INSERT INTO email_account_validity(user_id, expiration_ts_ms) VALUES(?, ?)",
+            (self.expired_user, now_ms - 1000),
+        )
+
+        txn.execute(
+            "INSERT INTO email_account_validity(user_id, expiration_ts_ms) VALUES(?, ?)",
+            (self.valid_user, now_ms + 100000),
+        )
+
+        store.conn.commit()
+
+    def _update_expiration_ts(self, store: SQLiteStore, user_id: str, ts: int) -> None:
+        """Update the expiration timestamp of a given user.
+
+        Args:
+            store: the store to use to perform the update.
+            user_id: the user to update the expiration timestamp of.
+            ts: the new timestamp.
+        """
+        txn = store.conn.cursor()
+
+        txn.execute(
+            "UPDATE email_account_validity SET expiration_ts_ms = ? WHERE user_id = ?",
+            (ts, user_id),
+        )
+
+        store.conn.commit()
+
+    async def test_add_expired(self) -> None:
+        """Tests that an expired user is correctly added to the red list."""
+        module, api, store = await create_module()
+        self._setup_account_validity(store)
+
+        # Check that the user is not in the list before we run the update. This also
+        # allows us to populate the _get_user_status cache, and check later that it's
+        # been correctly invalidated.
+        in_list, because_expired = await module._get_user_status(self.expired_user)
+        self.assertFalse(in_list)
+        self.assertFalse(because_expired)
+
+        # Run the update and check that the expired user got added to the red list (but
+        # not the still valid one)
+        await module._add_expired_users()
+
+        in_list, because_expired = await module._get_user_status(self.expired_user)
+        self.assertTrue(in_list)
+        self.assertTrue(because_expired)
+
+        in_list, because_expired = await module._get_user_status(self.valid_user)
+        self.assertFalse(in_list)
+        self.assertFalse(because_expired)
+
+        # Run the update to remove renewed users and check that nothing has changed.
+        await module._remove_renewed_users()
+
+        in_list, because_expired = await module._get_user_status(self.expired_user)
+        self.assertTrue(in_list)
+        self.assertTrue(because_expired)
+
+        in_list, because_expired = await module._get_user_status(self.valid_user)
+        self.assertFalse(in_list)
+        self.assertFalse(because_expired)
+
+    async def test_remove_renewed(self) -> None:
+        """Tests that a user that was added to the red list after expiring but renewed
+        their account since is correctly removed from it."""
+        module, api, store = await create_module()
+        self._setup_account_validity(store)
+
+        await module._add_expired_users()
+
+        in_list, because_expired = await module._get_user_status(self.expired_user)
+        self.assertTrue(in_list)
+        self.assertTrue(because_expired)
+
+        now_ts = int(time.time() * 1000)
+        self._update_expiration_ts(store, self.expired_user, now_ts + 100)
+
+        await module._remove_renewed_users()
+
+        in_list, because_expired = await module._get_user_status(self.expired_user)
+        self.assertFalse(in_list)
+        self.assertFalse(because_expired)
+
+    async def test_update_after_renewed(self) -> None:
+        """Tests that if a user adds themselves to the red list manually before the
+        update that automatically removes the renewed users, they don't get removed.
+        """
+        module, api, store = await create_module()
+        self._setup_account_validity(store)
+
+        # Add the user to the red list automatically.
+        await module._add_expired_users()
+
+        in_list, because_expired = await module._get_user_status(self.expired_user)
+        self.assertTrue(in_list)
+        self.assertTrue(because_expired)
+
+        # Renew the user. We can do this anywhere as long as it's before the call to
+        # _remove_renewed_users, but doing this here is more natural as in real life
+        # users aren't permitted to update their account data if they're expired.
+        now_ts = int(time.time() * 1000)
+        self._update_expiration_ts(store, self.expired_user, now_ts + 100)
+
+        # Manually hide the user's profile.
+        await module.update_red_list_status(
+            user_id=self.expired_user,
+            room_id=None,
+            account_data_type=ACCOUNT_DATA_TYPE,
+            content={"hide_profile": True},
+        )
+
+        # Check that the user is still in the list but its because_expired flag has
+        # changed.
+        in_list, because_expired = await module._get_user_status(self.expired_user)
+        self.assertTrue(in_list)
+        self.assertFalse(because_expired)
+
+        # Run the update and check that the user is still there.
+        await module._remove_renewed_users()
+
+        in_list, because_expired = await module._get_user_status(self.expired_user)
+        self.assertTrue(in_list)
+        self.assertFalse(because_expired)

--- a/tests/test_red_list.py
+++ b/tests/test_red_list.py
@@ -28,7 +28,7 @@ class RedListTestCase(aiounittest.AsyncTestCase):
         """Tests that incoming account data with a different account data type than the
         one the module handles is ignored.
         """
-        module, api = await create_module()
+        module, api, _ = await create_module()
 
         account_data_type = "org.matrix.foo"
 
@@ -74,7 +74,7 @@ class RedListTestCase(aiounittest.AsyncTestCase):
 
     async def test_status_cached(self) -> None:
         """Tests that users statuses are correctly cached and invalidated."""
-        module, api = await create_module()
+        module, api, _ = await create_module()
 
         # Get the user's status and check we made a database call.
         in_list, _ = await module._get_user_status(self.user_id)
@@ -118,7 +118,7 @@ class RedListTestCase(aiounittest.AsyncTestCase):
 
     async def test_add_to_list_no_discovery(self) -> None:
         """Tests adding a user to the red list (with no discovery room)"""
-        module, api = await create_module()
+        module, api, _ = await create_module()
 
         await module.update_red_list_status(
             user_id=self.user_id,
@@ -159,7 +159,7 @@ class RedListTestCase(aiounittest.AsyncTestCase):
     async def test_add_to_list_discovery(self) -> None:
         """Tests adding a user to the red list (with a discovery room)"""
         room_id = "!someroom:test"
-        module, api = await create_module({"discovery_room": room_id})
+        module, api, _ = await create_module({"discovery_room": room_id})
 
         await module.update_red_list_status(
             user_id=self.user_id,
@@ -220,7 +220,7 @@ class RedListTestCase(aiounittest.AsyncTestCase):
         Returns:
             The return values from create_module.
         """
-        module, api = await create_module(config)
+        module, api, _ = await create_module(config)
         await module._add_to_red_list(self.user_id)
         # Reset the mocks, so the action we just performed doesn't interfere with the
         # call counts.


### PR DESCRIPTION
Uses the `because_expired` column introduced by #1 to automatically add, remove and track users in the red list depending on their account validity status.

Based off #1.

See https://docs.google.com/document/d/1wQw1OMgqn0blbv4Jt7ApZhR8mtN39ZLkNHKuNY-Xd_M/edit#heading=h.5215td309oo5 for more information, specifically:

> It must also implement a recurring task to look for the [email-account-validity](https://github.com/matrix-org/synapse-email-account-validity) table, and if it's there add the expired users to the red list. We'll also need to remove them when they get reactivated, so the table should include a "reason" column or similar (to distinguish users being put on the red list by this process and users adding themselves before expiring). The equivalent job on synapse-dinsic runs every hour, so the job running on the module should probably do the same. As a side note, having a module use the database table of another module is generally not considered best practice, but we don't really have another way to do this (apart from reading the `users` table and asking the account validity module if each user is expired, which is equally nasty). It should be fine though, as the understanding is that account validity in Tchap is likely to go away at some point in the future.

CI failures are expected for the same reason as #1